### PR TITLE
Update validateBpayCRN

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,6 @@ var validateBpayCRN = exports.validateBpayCRN = function(input) {
 	
 	input = String(input);
 	
-	return (input.length == 10 && validateLuhnCheckDigit(input));
+	return (input.length >= 2 && input.length <= 20 && validateLuhnCheckDigit(input));
 	
 }


### PR DESCRIPTION
Hey, good work with a simple to use BPAY CRN generator. I noticed that the validation method forces 10 digits, here's a fix for that.

Fix from forcing 10 digit length to accepting 2-20 digit length.
